### PR TITLE
Removed Unnecessary Warnings

### DIFF
--- a/src/editor/toolmasks.md
+++ b/src/editor/toolmasks.md
@@ -39,4 +39,6 @@ The 'Neighbor' condition returns true when any of the six blocks directly adjace
 > **IMPORTANT**
 > 
 > The tool masks window must be open in order to take effect. You may dock the window to the side in order to have it open all the time.
-
+>
+> Tools currently incompatible with Masks:
+> - Slope Tool

--- a/src/editor/toolmasks.md
+++ b/src/editor/toolmasks.md
@@ -39,11 +39,4 @@ The 'Neighbor' condition returns true when any of the six blocks directly adjace
 > **IMPORTANT**
 > 
 > The tool masks window must be open in order to take effect. You may dock the window to the side in order to have it open all the time.
->
-> Tools currently incompatible with Masks:
-> - Smooth Tool
-> - Distort Tool
-> - Roughen Tool
-> - Shatter Tool
-> - Extrude Tool
 


### PR DESCRIPTION
Removed the warning for tool masks not working for certain tools, since support was added in a recent update