### PR TITLE
Removed warning for box select

### DIFF
--- a/src/tools/selection/boxselect.md
+++ b/src/tools/selection/boxselect.md
@@ -3,5 +3,3 @@
 The **Box Select** tool allows you to create cuboid selections. To start, click and drag between two points. The selection can be further refined by repositioning the 3 [Gizmos](/editor/gizmos.md).
 
 If you want to select between two known coordinates instead, these coordinates can be entered into the tool's options.
-
-> Warning: Some users try to use the tool by clicking twice. This does not work, you must drag to create the initial box


### PR DESCRIPTION
Support for clicking twice was added in a recent update